### PR TITLE
Bremen Ground

### DIFF
--- a/EDWW AUTO ATIS.json
+++ b/EDWW AUTO ATIS.json
@@ -2620,7 +2620,7 @@
                 {
                     "text": "@GND",
                     "ordinal": 1,
-                    "enabled": true
+                    "enabled": false
                 },
                 {
                     "text": "@ADV 122.800.",

--- a/EDWW AUTO ATIS.json
+++ b/EDWW AUTO ATIS.json
@@ -2551,7 +2551,7 @@
                 {
                     "variableName": "GND",
                     "text": "FOR START UP AND TAXI CONTACT GROUND CONTROL ON 121.755",
-                    "voice": "FOR START UP AND TAXI CONTACT GROUND CONTROL ON 121,755"
+                    "voice": "FOR START UP AND TAXI CONTACT GROUND CONTROL ON 121 DECIMAL 755"
                 },
                 {
                     "variableName": "ACTIVE_27",

--- a/EDWW AUTO ATIS.json
+++ b/EDWW AUTO ATIS.json
@@ -3,7 +3,7 @@
     "name": "EDWW ATIS 22 Mar 2025",
     "id": "0f60728d-87e0-4aea-addb-f3c8ebbf3ac7",
     "updateUrl": "https://raw.githubusercontent.com/VATGER-Nav/edww-vatis/refs/heads/main/EDWW%20AUTO%20ATIS.json",
-    "updateSerial": 2025032201,
+    "updateSerial": 2025032202,
     "stations": [
         {
             "id": "3bbcc80d-7137-41e8-a527-8f2ae8b4c590",

--- a/EDWW AUTO ATIS.json
+++ b/EDWW AUTO ATIS.json
@@ -2549,6 +2549,11 @@
                     "voice": "WHEN AIRBORNE MONITOR ADVISORY"
                 },
                 {
+                    "variableName": "GND",
+                    "text": "FOR START UP AND TAXI CONTACT GROUND CONTROL ON 121.755",
+                    "voice": "FOR START UP AND TAXI CONTACT GROUND CONTROL ON 121,755"
+                },
+                {
                     "variableName": "ACTIVE_27",
                     "text": "RWY 27",
                     "voice": "RUNWAY IN USE ^27."
@@ -2613,58 +2618,63 @@
             ],
             "notamDefinitions": [
                 {
-                    "text": "@ADV 122.800.",
+                    "text": "@GND",
                     "ordinal": 1,
                     "enabled": true
                 },
                 {
-                    "text": "@DEPFREQ 124.800.",
+                    "text": "@ADV 122.800.",
                     "ordinal": 2,
-                    "enabled": false
+                    "enabled": true
                 },
                 {
-                    "text": "@DEPFREQ 124.075.",
+                    "text": "@DEPFREQ 124.800.",
                     "ordinal": 3,
                     "enabled": false
                 },
                 {
-                    "text": "@DEPFREQ 126.325.",
+                    "text": "@DEPFREQ 124.075.",
                     "ordinal": 4,
                     "enabled": false
                 },
                 {
-                    "text": "@DEPFREQ 127.675.",
+                    "text": "@DEPFREQ 126.325.",
                     "ordinal": 5,
                     "enabled": false
                 },
                 {
-                    "text": "@DEPFREQ 133.725.",
+                    "text": "@DEPFREQ 127.675.",
                     "ordinal": 6,
                     "enabled": false
                 },
                 {
-                    "text": "@IFR_CLR 124.800.",
+                    "text": "@DEPFREQ 133.725.",
                     "ordinal": 7,
                     "enabled": false
                 },
                 {
-                    "text": "@IFR_CLR 124.075.",
+                    "text": "@IFR_CLR 124.800.",
                     "ordinal": 8,
                     "enabled": false
                 },
                 {
-                    "text": "@IFR_CLR 126.325.",
+                    "text": "@IFR_CLR 124.075.",
                     "ordinal": 9,
                     "enabled": false
                 },
                 {
-                    "text": "@IFR_CLR 127.675.",
+                    "text": "@IFR_CLR 126.325.",
                     "ordinal": 10,
                     "enabled": false
                 },
                 {
-                    "text": "@IFR_CLR 133.725.",
+                    "text": "@IFR_CLR 127.675.",
                     "ordinal": 11,
+                    "enabled": false
+                },
+                {
+                    "text": "@IFR_CLR 133.725.",
+                    "ordinal": 12,
                     "enabled": false
                 }
             ]


### PR DESCRIPTION
When Bremen Ground is open, then in the real life ATIS it will add the bold text:

-ATIS EDDW J METAR 220950 -EXPECT RADAR VECTORED ILS Z APCH -RWY 09 -RWY COND RWY 09 AT TIME 0443 RWYCC 6 DEPOSIT TOTAL RWY DRY **FOR START UP AND TAXI CONTACT GROUND CONTROL ON 121.755** -TRL 70 -CAUTION GLD FLYING ACTIVITIES PSN 8 NM WSW EDDW AD -10016G28KT 070V130 -CAVOK - - -T15 DP00 -QNH1011 - -TREND NOSIG 